### PR TITLE
feat: separate Redis instances for each microservice

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,10 @@ services:
       - "8000:8000"
     env_file:
       - ./backend/user-service/.env.docker
+    environment:
+      - REDIS_URL=redis://user-service-redis:6379
     depends_on:
-      redis:
+      user-service-redis:
         condition: service_healthy
     networks:
       - peerprep-network
@@ -42,6 +44,11 @@ services:
       - "8001:8001" 
     env_file:
       - ./backend/question-service/.env.docker
+    environment:
+      - REDIS_URL=redis://question-service-redis:6380
+    depends_on:
+      question-service-redis:
+        condition: service_healthy
     networks:
       - peerprep-network
     healthcheck:
@@ -64,10 +71,13 @@ services:
       - QUESTION_SERVICE_URL=http://question-service:8001
       - NODE_ENV=production
       - MATCHING_TIMEOUT_MS=60000
+      - REDIS_URL=redis://matching-service-redis:6381
     depends_on:
       collaboration-service:
         condition: service_healthy
       question-service:
+        condition: service_healthy
+      matching-service-redis:
         condition: service_healthy
     networks:
       - peerprep-network
@@ -86,8 +96,10 @@ services:
       - "8002:8002"
     env_file:
       - ./backend/collaboration-service/.env.docker
+    environment:
+      - REDIS_URL=redis://collaboration-service-redis:6382
     depends_on:
-      redis:
+      collaboration-service-redis:
         condition: service_healthy
     networks:
       - peerprep-network
@@ -99,18 +111,73 @@ services:
       start_period: 10s
     restart: unless-stopped
 
-  # Redis - Session storage and caching
-  redis:
+  # Redis instances for each service - separated for scalability
+  user-service-redis:
     container_name: user-service-redis
     image: redis:7-alpine
     ports:
       - "6379:6379"
+    command: redis-server --port 6379 --appendonly yes
     volumes:
-      - redis_data:/data
+      - user_redis_data:/data
     networks:
       - peerprep-network
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-p", "6379", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+  question-service-redis:
+    container_name: question-service-redis
+    image: redis:7-alpine
+    ports:
+      - "6380:6380"
+    command: redis-server --port 6380 --appendonly yes
+    volumes:
+      - question_redis_data:/data
+    networks:
+      - peerprep-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6380", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+  matching-service-redis:
+    container_name: matching-service-redis
+    image: redis:7-alpine
+    ports:
+      - "6381:6381"
+    command: redis-server --port 6381 --appendonly yes
+    volumes:
+      - matching_redis_data:/data
+    networks:
+      - peerprep-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6381", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+  collaboration-service-redis:
+    container_name: collaboration-service-redis
+    image: redis:7-alpine
+    ports:
+      - "6382:6382"
+    command: redis-server --port 6382 --appendonly yes
+    volumes:
+      - collaboration_redis_data:/data
+    networks:
+      - peerprep-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6382", "ping"]
       interval: 10s
       timeout: 3s
       retries: 3
@@ -122,4 +189,7 @@ networks:
     driver: bridge
 
 volumes:
-  redis_data:
+  user_redis_data:
+  question_redis_data:
+  matching_redis_data:
+  collaboration_redis_data:

--- a/k8s/configmaps/collaboration-service-configmap.yaml
+++ b/k8s/configmaps/collaboration-service-configmap.yaml
@@ -14,7 +14,7 @@ data:
 
   # Redis Configuration
   REDIS_ENABLED: 'true'
-  REDIS_URL: 'redis://redis-service:6379'
+  REDIS_URL: 'redis://collaboration-service-redis-service:6382'
 
   # Session Configuration
   SESSION_TIMEOUT: '3600000'

--- a/k8s/configmaps/matching-service-configmap.yaml
+++ b/k8s/configmaps/matching-service-configmap.yaml
@@ -9,7 +9,7 @@ data:
   PORT: '8003'
 
   # Redis Configuration
-  REDIS_URL: 'redis://redis-service:6379'
+  REDIS_URL: 'redis://matching-service-redis-service:6381'
 
   # CORS Configuration (will be updated after you get domain/IP)
   # For now allowing all, update after deployment for security

--- a/k8s/configmaps/question-service-configmap.yaml
+++ b/k8s/configmaps/question-service-configmap.yaml
@@ -12,6 +12,9 @@ data:
   # For now allowing all, update after deployment for security
   ALLOWED_ORIGINS: 'http://34.8.234.19'
 
+  # Redis Configuration
+  REDIS_URL: 'redis://question-service-redis-service:6380'
+
   # GCP Configuration
   GCP_PROJECT_ID: 'peerprep-475911'
   USE_SECRET_MANAGER: 'true'

--- a/k8s/configmaps/user-service-configmap.yaml
+++ b/k8s/configmaps/user-service-configmap.yaml
@@ -10,7 +10,7 @@ data:
   ENV: 'PROD'
 
   # Redis Configuration
-  REDIS_URL: 'redis://redis-service:6379'
+  REDIS_URL: 'redis://user-service-redis-service:6379'
 
   # JWT Configuration (timeouts only, secrets from Secret Manager)
   JWT_EXPIRES_IN: '900'

--- a/k8s/redis/README.md
+++ b/k8s/redis/README.md
@@ -1,0 +1,81 @@
+# Redis Configuration
+
+This directory contains separate Redis instances for each microservice, configured for scalability and isolation.
+
+## Architecture
+
+Each service now has its own dedicated Redis instance running on different ports:
+
+- **user-service**: Port 6379 (default Redis port)
+- **question-service**: Port 6380
+- **matching-service**: Port 6381
+- **collaboration-service**: Port 6382
+
+## Deployment
+
+To deploy all Redis instances in Kubernetes:
+
+```bash
+# Deploy all Redis instances
+kubectl apply -f k8s/redis/user-service-redis.yaml
+kubectl apply -f k8s/redis/question-service-redis.yaml
+kubectl apply -f k8s/redis/matching-service-redis.yaml
+kubectl apply -f k8s/redis/collaboration-service-redis.yaml
+```
+
+## Benefits
+
+1. **Isolation**: Each service's data is completely isolated from others
+2. **Scalability**: Can scale each Redis instance independently based on service load
+3. **Performance**: Reduces contention and improves performance by eliminating shared resource bottlenecks
+4. **Reliability**: Failure in one Redis instance doesn't affect other services
+5. **Resource Management**: Can allocate different resource limits per service needs
+
+## Local Development
+
+For local development using Docker Compose, separate Redis instances are configured in `docker-compose.yml`:
+
+- Each Redis instance uses a separate volume for data persistence
+- Ports are mapped to avoid conflicts
+- Each service connects to its dedicated Redis instance via environment variables
+
+## Configuration
+
+Each service connects to its Redis instance via the `REDIS_URL` environment variable defined in their respective ConfigMaps:
+
+- `user-service`: `redis://user-service-redis-service:6379`
+- `question-service`: `redis://question-service-redis-service:6380`
+- `matching-service`: `redis://matching-service-redis-service:6381`
+- `collaboration-service`: `redis://collaboration-service-redis-service:6382`
+
+## Monitoring
+
+To check the status of Redis instances:
+
+```bash
+# Check Redis pods
+kubectl get pods -n peerprep | grep redis
+
+# Check Redis services
+kubectl get svc -n peerprep | grep redis
+
+# Check logs for a specific Redis instance
+kubectl logs -n peerprep <redis-pod-name>
+```
+
+## Scaling
+
+Each Redis StatefulSet can be scaled independently:
+
+```bash
+# Scale user-service Redis to 3 replicas
+kubectl scale statefulset user-service-redis -n peerprep --replicas=3
+
+# Scale collaboration-service Redis to 2 replicas
+kubectl scale statefulset collaboration-service-redis -n peerprep --replicas=2
+```
+
+## Note
+
+Redis supports custom ports through the `--port` flag, which allows us to run multiple Redis instances on the same cluster without conflicts. Each service connects to its dedicated Redis instance using the appropriate port.
+

--- a/k8s/redis/collaboration-service-redis.yaml
+++ b/k8s/redis/collaboration-service-redis.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: collaboration-service-redis
+  namespace: peerprep
+  labels:
+    app: collaboration-service-redis
+spec:
+  serviceName: collaboration-service-redis-service
+  replicas: 1
+  selector:
+    matchLabels:
+      app: collaboration-service-redis
+  template:
+    metadata:
+      labels:
+        app: collaboration-service-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6382
+              name: redis
+          command:
+            - redis-server
+            - --appendonly
+            - 'yes'
+            - --save
+            - '60 1'
+            - --port
+            - '6382'
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+          resources:
+            requests:
+              memory: '128Mi'
+              cpu: '100m'
+            limits:
+              memory: '256Mi'
+              cpu: '200m'
+          livenessProbe:
+            tcpSocket:
+              port: 6382
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 6382
+            initialDelaySeconds: 5
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes: ['ReadWriteOnce']
+        resources:
+          requests:
+            storage: 1Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: collaboration-service-redis-service
+  namespace: peerprep
+  labels:
+    app: collaboration-service-redis
+spec:
+  clusterIP: None # Headless service for StatefulSet
+  selector:
+    app: collaboration-service-redis
+  ports:
+    - port: 6382
+      targetPort: 6382
+      protocol: TCP
+      name: redis
+

--- a/k8s/redis/matching-service-redis.yaml
+++ b/k8s/redis/matching-service-redis.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: matching-service-redis
+  namespace: peerprep
+  labels:
+    app: matching-service-redis
+spec:
+  serviceName: matching-service-redis-service
+  replicas: 1
+  selector:
+    matchLabels:
+      app: matching-service-redis
+  template:
+    metadata:
+      labels:
+        app: matching-service-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6381
+              name: redis
+          command:
+            - redis-server
+            - --appendonly
+            - 'yes'
+            - --save
+            - '60 1'
+            - --port
+            - '6381'
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+          resources:
+            requests:
+              memory: '128Mi'
+              cpu: '100m'
+            limits:
+              memory: '256Mi'
+              cpu: '200m'
+          livenessProbe:
+            tcpSocket:
+              port: 6381
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 6381
+            initialDelaySeconds: 5
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes: ['ReadWriteOnce']
+        resources:
+          requests:
+            storage: 1Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: matching-service-redis-service
+  namespace: peerprep
+  labels:
+    app: matching-service-redis
+spec:
+  clusterIP: None # Headless service for StatefulSet
+  selector:
+    app: matching-service-redis
+  ports:
+    - port: 6381
+      targetPort: 6381
+      protocol: TCP
+      name: redis
+

--- a/k8s/redis/question-service-redis.yaml
+++ b/k8s/redis/question-service-redis.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: question-service-redis
+  namespace: peerprep
+  labels:
+    app: question-service-redis
+spec:
+  serviceName: question-service-redis-service
+  replicas: 1
+  selector:
+    matchLabels:
+      app: question-service-redis
+  template:
+    metadata:
+      labels:
+        app: question-service-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6380
+              name: redis
+          command:
+            - redis-server
+            - --appendonly
+            - 'yes'
+            - --save
+            - '60 1'
+            - --port
+            - '6380'
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+          resources:
+            requests:
+              memory: '128Mi'
+              cpu: '100m'
+            limits:
+              memory: '256Mi'
+              cpu: '200m'
+          livenessProbe:
+            tcpSocket:
+              port: 6380
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 6380
+            initialDelaySeconds: 5
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes: ['ReadWriteOnce']
+        resources:
+          requests:
+            storage: 1Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: question-service-redis-service
+  namespace: peerprep
+  labels:
+    app: question-service-redis
+spec:
+  clusterIP: None # Headless service for StatefulSet
+  selector:
+    app: question-service-redis
+  ports:
+    - port: 6380
+      targetPort: 6380
+      protocol: TCP
+      name: redis
+

--- a/k8s/redis/user-service-redis.yaml
+++ b/k8s/redis/user-service-redis.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: user-service-redis
+  namespace: peerprep
+  labels:
+    app: user-service-redis
+spec:
+  serviceName: user-service-redis-service
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-service-redis
+  template:
+    metadata:
+      labels:
+        app: user-service-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+              name: redis
+          command:
+            - redis-server
+            - --appendonly
+            - 'yes'
+            - --save
+            - '60 1'
+            - --port
+            - '6379'
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+          resources:
+            requests:
+              memory: '128Mi'
+              cpu: '100m'
+            limits:
+              memory: '256Mi'
+              cpu: '200m'
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes: ['ReadWriteOnce']
+        resources:
+          requests:
+            storage: 1Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service-redis-service
+  namespace: peerprep
+  labels:
+    app: user-service-redis
+spec:
+  clusterIP: None # Headless service for StatefulSet
+  selector:
+    app: user-service-redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP
+      name: redis
+


### PR DESCRIPTION
## 🔄 Refactor: Separate Redis Instances for Each Microservice

### Summary
This PR refactors the Redis architecture to use separate dedicated Redis instances for each microservice instead of a shared single instance. This improves scalability, isolation, and allows independent resource management per service.

### Changes Made

#### Kubernetes Configuration
- Created 4 new Redis StatefulSets:
  - `user-service-redis` on port 6379
  - `question-service-redis` on port 6380
  - `matching-service-redis` on port 6381
  - `collaboration-service-redis` on port 6382
- Updated all service ConfigMaps to point to their dedicated Redis instances
- Each Redis instance has its own persistent volume and resource limits

#### Docker Compose (Local Development)
- Replaced single Redis container with 4 separate Redis containers
- Added separate volumes for each Redis instance
- Updated service dependencies and environment variables

### Deployment Steps

```bash
# Deploy all Redis instances
kubectl apply -f k8s/redis/user-service-redis.yaml
kubectl apply -f k8s/redis/question-service-redis.yaml
kubectl apply -f k8s/redis/matching-service-redis.yaml
kubectl apply -f k8s/redis/collaboration-service-redis.yaml
```
Closes #49 #50 
