### PR TITLE
feat(frontend): integrate history service to frontend

### DIFF
--- a/frontend/src/app/(main)/history/page.tsx
+++ b/frontend/src/app/(main)/history/page.tsx
@@ -1,58 +1,92 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import HistoryTable, { type HistoryItem } from '@/components/HistoryTable';
 import Header from '@/components/ui/Header';
+import { useAuth } from '@/contexts/AuthContext';
+import historyService, { HistoryEntry } from '@/services/history.service';
+import { useRouter } from 'next/navigation';
 
-const sampleData: HistoryItem[] = [
-  {
-    id: 1,
-    title: 'Two Sum',
-    difficulty: 'Easy',
-    topics: ['HashMap'],
-    tags: ['Beginner-friendly', 'Completed'],
-  },
-  {
-    id: 2,
-    title: 'Longest Substring Without Repeating Characters',
-    difficulty: 'Medium',
-    topics: ['Sliding Window', 'Two Pointers'],
-    tags: ['Interview Question', 'Popular'],
-  },
-  {
-    id: 3,
-    title: 'Merge Two Sorted Lists',
-    difficulty: 'Easy',
-    topics: ['Two Pointers', 'Sorting'],
-    tags: ['Beginner-friendly'],
-  },
-  {
-    id: 4,
-    title: 'Remove Duplicates From Sorted Array',
-    difficulty: 'Easy',
-    topics: ['Two Pointers'],
-    tags: ['Beginner-friendly', 'Completed'],
-  },
-  {
-    id: 5,
-    title: 'Median of Two Sorted Arrays',
-    difficulty: 'Hard',
-    topics: ['Two Pointers'],
-    tags: [],
-  },
-  {
-    id: 6,
-    title: 'N-Queens',
-    difficulty: 'Hard',
-    topics: ['SSSP'],
-    tags: ['Completed'],
-  },
-];
+const ITEMS_PER_PAGE = 10;
 
 export default function HistoryPage() {
+  const { user, isAuthenticated } = useAuth();
+  const router = useRouter();
+  const [historyData, setHistoryData] = useState<HistoryItem[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalItems, setTotalItems] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Redirect to login if not authenticated
+    if (!isAuthenticated) {
+      router.push('/auth/login');
+      return;
+    }
+
+    // Fetch history when user is available
+    if (user?.id) {
+      fetchHistory(currentPage);
+    }
+  }, [user, currentPage, isAuthenticated, router]);
+
+  const fetchHistory = async (page: number) => {
+    if (!user?.id) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const offset = (page - 1) * ITEMS_PER_PAGE;
+      const response = await historyService.getUserHistory(user.id, ITEMS_PER_PAGE, offset);
+
+      // Transform API response to match HistoryItem interface
+      const transformedData: HistoryItem[] = response.data.map((entry: HistoryEntry) => ({
+        id: entry.id,
+        title: entry.question_title,
+        difficulty: entry.difficulty,
+        category: entry.category,
+        created_at: entry.created_at,
+        session_id: entry.session_id,
+      }));
+
+      setHistoryData(transformedData);
+      setTotalItems(response.count);
+    } catch (err) {
+      console.error('Failed to fetch history:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load history');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  if (!isAuthenticated) {
+    return null; // Will redirect in useEffect
+  }
+
   return (
     <div className="container mx-auto max-w-5xl px-4 py-10">
-      <Header className="text-center">History</Header>
-      <HistoryTable items={sampleData} />
+      <Header className="text-center mb-8">History</Header>
+
+      {error && (
+        <div className="mb-4 p-4 bg-destructive/10 border border-destructive rounded-lg text-destructive text-center">
+          {error}
+        </div>
+      )}
+
+      <HistoryTable
+        items={historyData}
+        currentPage={currentPage}
+        totalItems={totalItems}
+        itemsPerPage={ITEMS_PER_PAGE}
+        onPageChange={handlePageChange}
+        isLoading={isLoading}
+      />
     </div>
   );
 }

--- a/frontend/src/components/HistoryTable.tsx
+++ b/frontend/src/components/HistoryTable.tsx
@@ -1,54 +1,166 @@
 'use client';
 
+import { Fragment } from 'react';
+import { Button } from '@/components/ui/button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
 export type HistoryItem = {
-  id: number;
+  id: string;
   title: string;
   difficulty: 'Easy' | 'Medium' | 'Hard';
-  topics: string[];
-  tags: string[];
+  category: string;
+  created_at: string;
+  session_id?: string;
 };
 
 type Props = {
   items: HistoryItem[];
   className?: string;
+  // Pagination props
+  currentPage?: number;
+  totalItems?: number;
+  itemsPerPage?: number;
+  onPageChange?: (page: number) => void;
+  isLoading?: boolean;
 };
 
 /**
  * Simple, accessible table styled with Tailwind.
  * Designed to match the look-and-feel in the History mock.
  */
-export default function HistoryTable({ items, className }: Props) {
+export default function HistoryTable({
+  items,
+  className,
+  currentPage = 1,
+  totalItems = 0,
+  itemsPerPage = 10,
+  onPageChange,
+  isLoading = false,
+}: Props) {
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const startIndex = (currentPage - 1) * itemsPerPage + 1;
+  const endIndex = Math.min(currentPage * itemsPerPage, totalItems);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
   return (
-    <div className={`w-full overflow-x-auto ${className ?? ''}`}>
+    <div className={`w-full ${className ?? ''}`}>
       <div className="rounded-xl border bg-card text-card-foreground shadow-sm">
-        <table className="w-full caption-bottom text-sm">
-          <thead className="[&_th]:py-3 [&_th]:px-4">
-            <tr className="border-b bg-muted/60 text-muted-foreground">
-              <th className="text-left w-[90px]">ID No.</th>
-              <th className="text-left min-w-[220px]">Question Title</th>
-              <th className="text-left w-[110px]">Difficulty</th>
-              <th className="text-left min-w-[180px]">Topics</th>
-              <th className="text-left min-w-[200px]">Tags</th>
-            </tr>
-          </thead>
-          <tbody className="[&_td]:py-4 [&_td]:px-4">
-            {items.map((row) => (
-              <tr key={row.id} className="border-b last:border-0 hover:bg-muted/40">
-                <td className="align-top text-muted-foreground">{row.id}</td>
-                <td className="align-top font-medium">{row.title}</td>
-                <td className="align-top">
-                  <DifficultyPill value={row.difficulty} />
-                </td>
-                <td className="align-top">
-                  <ChipList values={row.topics} />
-                </td>
-                <td className="align-top">
-                  <ChipList values={row.tags} />
-                </td>
+        <div className="overflow-x-auto">
+          <table className="w-full caption-bottom text-sm">
+            <thead className="[&_th]:py-3 [&_th]:px-4">
+              <tr className="border-b bg-muted/60 text-muted-foreground">
+                <th className="text-left w-[90px]">No.</th>
+                <th className="text-left min-w-[120px]">Session ID</th>
+                <th className="text-left min-w-[220px]">Question Title</th>
+                <th className="text-left w-[110px]">Difficulty</th>
+                <th className="text-left min-w-[150px]">Category</th>
+                <th className="text-left min-w-[180px]">Date Attempted</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="[&_td]:py-4 [&_td]:px-4">
+              {isLoading ? (
+                <tr>
+                  <td colSpan={6} className="text-center py-8 text-muted-foreground">
+                    Loading...
+                  </td>
+                </tr>
+              ) : items.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="text-center py-8 text-muted-foreground">
+                    No history entries found
+                  </td>
+                </tr>
+              ) : (
+                items.map((row, index) => (
+                  <tr key={row.id} className="border-b last:border-0 hover:bg-muted/40">
+                    <td className="align-top text-muted-foreground">{startIndex + index}</td>
+                    <td className="align-top text-muted-foreground text-xs">
+                      {row.session_id || '—'}
+                    </td>
+                    <td className="align-top font-medium">{row.title}</td>
+                    <td className="align-top">
+                      <DifficultyPill value={row.difficulty} />
+                    </td>
+                    <td className="align-top">
+                      <span className="inline-flex items-center rounded-md border px-2 py-1 text-xs text-muted-foreground">
+                        {row.category}
+                      </span>
+                    </td>
+                    <td className="align-top text-muted-foreground text-xs">
+                      {formatDate(row.created_at)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between border-t px-4 py-3">
+            <div className="text-sm text-muted-foreground">
+              Showing {startIndex} to {endIndex} of {totalItems} entries
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange?.(currentPage - 1)}
+                disabled={currentPage === 1 || isLoading}
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Previous
+              </Button>
+              <div className="flex items-center gap-1">
+                {Array.from({ length: totalPages }, (_, i) => i + 1)
+                  .filter((page) => {
+                    // Show first page, last page, current page, and pages around current
+                    return page === 1 || page === totalPages || Math.abs(page - currentPage) <= 1;
+                  })
+                  .map((page, index, arr) => {
+                    // Add ellipsis if there's a gap
+                    const showEllipsisBefore = index > 0 && page - arr[index - 1] > 1;
+                    return (
+                      <Fragment key={page}>
+                        {showEllipsisBefore && (
+                          <span className="px-2 text-muted-foreground">...</span>
+                        )}
+                        <Button
+                          variant={currentPage === page ? 'default' : 'outline'}
+                          size="sm"
+                          className="w-9"
+                          onClick={() => onPageChange?.(page)}
+                          disabled={isLoading}
+                        >
+                          {page}
+                        </Button>
+                      </Fragment>
+                    );
+                  })}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange?.(currentPage + 1)}
+                disabled={currentPage === totalPages || isLoading}
+              >
+                Next
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -68,21 +180,5 @@ function DifficultyPill({ value }: { value: HistoryItem['difficulty'] }) {
     >
       {value}
     </span>
-  );
-}
-
-function ChipList({ values }: { values: string[] }) {
-  if (!values?.length) return <span className="text-muted-foreground">—</span>;
-  return (
-    <div className="flex flex-wrap gap-2">
-      {values.map((v, i) => (
-        <span
-          key={`${v}-${i}`}
-          className="inline-flex items-center rounded-md border px-2 py-1 text-xs text-muted-foreground"
-        >
-          {v}
-        </span>
-      ))}
-    </div>
   );
 }

--- a/frontend/src/services/history.service.ts
+++ b/frontend/src/services/history.service.ts
@@ -1,0 +1,133 @@
+/**
+ * History Service
+ *
+ * Handles all history-related API operations
+ */
+
+import apiClient from '@/lib/api/client';
+import { AxiosResponse } from 'axios';
+
+export interface HistoryEntry {
+  id: string;
+  user_id: string;
+  session_id?: string;
+  question_title: string;
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+  category: string;
+  created_at: string;
+}
+
+export interface GetHistoryResponse {
+  success: boolean;
+  count: number;
+  data: HistoryEntry[];
+  pagination: {
+    limit: number;
+    offset: number;
+  };
+}
+
+export interface CreateHistoryPayload {
+  user_id: string;
+  question_title: string;
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+  category: string;
+  session_id?: string;
+}
+
+export interface CreateHistoryResponse {
+  success: boolean;
+  message: string;
+  data: HistoryEntry;
+}
+
+/**
+ * Custom error class for history service errors
+ */
+export class HistoryServiceError extends Error {
+  public readonly statusCode?: number;
+  public readonly details?: Record<string, unknown>;
+
+  constructor(message: string, statusCode?: number, details?: Record<string, unknown>) {
+    super(message);
+    this.name = 'HistoryServiceError';
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+class HistoryService {
+  private readonly HISTORY_BASE_PATH = '/history';
+  private readonly HISTORY_SERVICE_URL =
+    process.env.NEXT_PUBLIC_API_HISTORY_URL || 'http://localhost:8004';
+
+  /**
+   * Get user's history
+   * GET /history?user_id={userId}&limit={limit}&offset={offset}
+   */
+  async getUserHistory(
+    userId: string,
+    limit: number = 50,
+    offset: number = 0,
+  ): Promise<GetHistoryResponse> {
+    try {
+      const response: AxiosResponse<GetHistoryResponse> = await apiClient.get(
+        `${this.HISTORY_SERVICE_URL}${this.HISTORY_BASE_PATH}`,
+        {
+          params: {
+            user_id: userId,
+            limit,
+            offset,
+          },
+        },
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Create a new history entry
+   * POST /history
+   */
+  async createHistoryEntry(payload: CreateHistoryPayload): Promise<CreateHistoryResponse> {
+    try {
+      const response: AxiosResponse<CreateHistoryResponse> = await apiClient.post(
+        `${this.HISTORY_SERVICE_URL}${this.HISTORY_BASE_PATH}`,
+        payload,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  private handleError(error: unknown): HistoryServiceError {
+    if (this.isAxiosError(error) && error.response) {
+      const message =
+        error.response.data?.message || error.response.data?.error || 'An error occurred';
+      const statusCode = error.response.status;
+      const details = error.response.data?.details as Record<string, unknown> | undefined;
+      return new HistoryServiceError(message, statusCode, details);
+    } else if (this.isAxiosError(error) && error.request) {
+      return new HistoryServiceError('No response from server. Please check your connection.');
+    } else if (error instanceof Error) {
+      return new HistoryServiceError(error.message);
+    } else {
+      return new HistoryServiceError('An unexpected error occurred');
+    }
+  }
+
+  private isAxiosError(error: unknown): error is {
+    response?: { status: number; data?: { message?: string; error?: string; details?: unknown } };
+    request?: unknown;
+  } {
+    return (
+      typeof error === 'object' && error !== null && ('response' in error || 'request' in error)
+    );
+  }
+}
+
+const historyService = new HistoryService();
+export default historyService;


### PR DESCRIPTION
This pull request refactors the History page to fetch and display user-specific history data from an API, replacing static sample data. It introduces a new `history.service.ts` for handling API interactions, updates the table to support pagination and improved error/loading states, and cleans up unused code. These changes make the History page dynamic, secure, and scalable.

**History page dynamic data and authentication:**
* The History page (`page.tsx`) now fetches real user history data via the new `historyService`, handles authentication (redirecting unauthenticated users to login), supports pagination, and displays loading/error states.

**History table improvements:**
* The `HistoryTable` component is updated to accept paginated data, show session IDs, categories, and attempt dates, and provide pagination controls. It removes unused topic/tag columns and chip list rendering. [[1]](diffhunk://#diff-21fb7056aac4e6bbb512be7bfe91bcfd708928385d0b643a49a2dac9091aee2bR3-R164) [[2]](diffhunk://#diff-21fb7056aac4e6bbb512be7bfe91bcfd708928385d0b643a49a2dac9091aee2bL73-L88)

**API service integration:**
* Adds `frontend/src/services/history.service.ts` to encapsulate all history-related API operations, including fetching and creating history entries, with robust error handling.

<img width="1368" height="352" alt="image" src="https://github.com/user-attachments/assets/b606aa42-6d81-421d-8720-7106f66dcfd8" />

close: #88 