### PR TITLE
feat: implement forgot password with OTP verification

### DIFF
--- a/backend/user-service/README.md
+++ b/backend/user-service/README.md
@@ -550,6 +550,105 @@ Note: The Docker setup includes Redis for token whitelisting and uses the enviro
     | 404 (Not Found)             | User with specified ID not found                   |
     | 500 (Internal Server Error) | Database or server error                           |
 
+## Forgot Password (OTP-based)
+
+The forgot password feature allows users to securely reset their password by verifying their email through an OTP (One-Time Password).
+
+### Initiate Password Reset
+
+- This endpoint sends a 6-digit OTP to the user's email for password reset.
+- HTTP Method: `POST`
+- Endpoint: http://localhost:3001/auth/password-reset/initiate
+- Body
+  - Required: `email` (string)
+
+    ```json
+    {
+      "email": "sample@gmail.com"
+    }
+    ```
+
+- Responses:
+
+    | Response Code               | Explanation                                        |
+    |-----------------------------|----------------------------------------------------|
+    | 200 (OK)                    | OTP sent successfully (always returns 200 for security) |
+    | 400 (Bad Request)           | Invalid email format or OTP cooldown active        |
+    | 500 (Internal Server Error) | Email service error or server error               |
+
+### Verify Password Reset OTP
+
+- This endpoint verifies the OTP without resetting the password (optional step for multi-step UIs).
+- HTTP Method: `POST`
+- Endpoint: http://localhost:3001/auth/password-reset/verify
+- Body
+  - Required: `email` (string), `otp` (string)
+
+    ```json
+    {
+      "email": "sample@gmail.com",
+      "otp": "123456"
+    }
+    ```
+
+- Responses:
+
+    | Response Code               | Explanation                                        |
+    |-----------------------------|----------------------------------------------------|
+    | 200 (OK)                    | OTP verified successfully                          |
+    | 400 (Bad Request)           | Invalid/expired OTP                                |
+    | 404 (Not Found)             | User not found                                     |
+    | 500 (Internal Server Error) | Database or server error                           |
+
+### Reset Password
+
+- This endpoint resets the user's password after OTP verification.
+- HTTP Method: `POST`
+- Endpoint: http://localhost:3001/auth/password-reset/reset
+- Body
+  - Required: `email` (string), `otp` (string), `newPassword` (string)
+
+    ```json
+    {
+      "email": "sample@gmail.com",
+      "otp": "123456",
+      "newPassword": "NewSecurePassword123!"
+    }
+    ```
+
+- Responses:
+
+    | Response Code               | Explanation                                        |
+    |-----------------------------|----------------------------------------------------|
+    | 200 (OK)                    | Password reset successfully                        |
+    | 400 (Bad Request)           | Invalid OTP, password validation failed            |
+    | 404 (Not Found)             | User not found                                     |
+    | 500 (Internal Server Error) | Database or server error                           |
+
+### Resend Password Reset OTP
+
+- This endpoint resends the password reset OTP to the user's email.
+- HTTP Method: `POST`
+- Endpoint: http://localhost:3001/auth/password-reset/resend-otp
+- Body
+  - Required: `email` (string)
+
+    ```json
+    {
+      "email": "sample@gmail.com"
+    }
+    ```
+
+- Responses:
+
+    | Response Code               | Explanation                                        |
+    |-----------------------------|----------------------------------------------------|
+    | 200 (OK)                    | OTP resent successfully (always returns 200 for security) |
+    | 400 (Bad Request)           | OTP cooldown active                                |
+    | 500 (Internal Server Error) | Email service error or server error               |
+
+For detailed API documentation including request/response examples and error codes, see [FORGOT_PASSWORD_API.md](./FORGOT_PASSWORD_API.md).
+
 ## API Endpoints Summary
 
 ### Authentication Routes (`/auth`)
@@ -561,6 +660,10 @@ Note: The Docker setup includes Redis for token whitelisting and uses the enviro
 - `POST /auth/send-otp` - Send email verification OTP
 - `POST /auth/verify-otp` - Verify email with OTP code
 - `GET /auth/verification-status` - Check email verification status
+- `POST /auth/password-reset/initiate` - Initiate password reset (sends OTP)
+- `POST /auth/password-reset/verify` - Verify password reset OTP
+- `POST /auth/password-reset/reset` - Reset password with OTP
+- `POST /auth/password-reset/resend-otp` - Resend password reset OTP
 
 ### User Routes (`/users`)
 - `POST /users` - Create new user (registration)

--- a/backend/user-service/controller/password-reset-controller.js
+++ b/backend/user-service/controller/password-reset-controller.js
@@ -1,0 +1,178 @@
+import { AUTH_ERRORS, sendErrorResponse } from '../errors/index.js';
+import { otpService } from '../services/otp-service.js';
+import * as passwordResetService from '../services/password-reset-service.js';
+
+export async function handleInitiatePasswordReset(req, res) {
+  try {
+    const { email } = req.body;
+
+    const result = await passwordResetService.initiatePasswordReset(email);
+
+    return res.status(200).json({
+      message: 'Password reset code sent to your email.',
+      data: {
+        email: result.email,
+        expiryMinutes: result.expiryMinutes,
+      },
+    });
+  } catch (error) {
+    console.error('Initiate password reset error:', error);
+
+    if (error.message === 'USER_NOT_FOUND') {
+      return res.status(200).json({
+        message: 'If an account with this email exists, a password reset code has been sent.',
+        data: {
+          email: req.body.email,
+        },
+      });
+    }
+
+    if (error.message === 'OTP_COOLDOWN') {
+      return res.status(400).json({
+        message: `Please wait ${error.remainingSeconds} seconds before requesting a new code`,
+        error: 'OTP_COOLDOWN',
+        retryAfterSeconds: error.remainingSeconds,
+      });
+    }
+
+    if (error.message === 'STORAGE_ERROR') {
+      return sendErrorResponse(res, AUTH_ERRORS.STORAGE_ERROR);
+    }
+
+    if (error.message === 'EMAIL_ERROR') {
+      return sendErrorResponse(res, AUTH_ERRORS.EMAIL_ERROR);
+    }
+
+    return sendErrorResponse(res, AUTH_ERRORS.SERVER_ERROR);
+  }
+}
+
+export async function handleVerifyPasswordResetOTP(req, res) {
+  try {
+    const { email, otp } = req.body;
+
+    const result = await passwordResetService.verifyPasswordResetOTP(email, otp);
+
+    return res.status(200).json({
+      message: 'OTP verified successfully. You can now reset your password.',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Verify password reset OTP error:', error);
+
+    if (error.message === 'USER_NOT_FOUND') {
+      return res.status(404).json({
+        message: 'User not found',
+        error: 'USER_NOT_FOUND',
+      });
+    }
+
+    if (error.message === 'MISSING_OTP') {
+      return sendErrorResponse(res, AUTH_ERRORS.MISSING_OTP);
+    }
+
+    if (error.message === 'INVALID_OTP' && error.validationResult) {
+      const { validationResult } = error;
+      const errorMessage = otpService.getErrorMessage(validationResult);
+
+      return res.status(400).json({
+        message: errorMessage,
+        error: validationResult.reason,
+        attemptsRemaining: validationResult.attemptsRemaining,
+      });
+    }
+
+    return sendErrorResponse(res, AUTH_ERRORS.SERVER_ERROR);
+  }
+}
+
+export async function handleResetPassword(req, res) {
+  try {
+    const { email, otp, newPassword } = req.body;
+
+    const result = await passwordResetService.resetPassword(email, otp, newPassword);
+
+    return res.status(200).json({
+      message: 'Password has been reset successfully. You can now log in with your new password.',
+      data: result,
+    });
+  } catch (error) {
+    console.error('Reset password error:', error);
+
+    if (error.message === 'USER_NOT_FOUND') {
+      return res.status(404).json({
+        message: 'User not found',
+        error: 'USER_NOT_FOUND',
+      });
+    }
+
+    if (error.message === 'MISSING_OTP') {
+      return sendErrorResponse(res, AUTH_ERRORS.MISSING_OTP);
+    }
+
+    if (error.message === 'MISSING_PASSWORD') {
+      return res.status(400).json({
+        message: 'New password is required',
+        error: 'MISSING_PASSWORD',
+      });
+    }
+
+    if (error.message === 'INVALID_OTP' && error.validationResult) {
+      const { validationResult } = error;
+      const errorMessage = otpService.getErrorMessage(validationResult);
+
+      return res.status(400).json({
+        message: errorMessage,
+        error: validationResult.reason,
+        attemptsRemaining: validationResult.attemptsRemaining,
+      });
+    }
+
+    return sendErrorResponse(res, AUTH_ERRORS.SERVER_ERROR);
+  }
+}
+
+export async function handleResendPasswordResetOTP(req, res) {
+  try {
+    const { email } = req.body;
+
+    const result = await passwordResetService.resendPasswordResetOTP(email);
+
+    return res.status(200).json({
+      message: 'Password reset code resent successfully',
+      data: {
+        email: result.email,
+        expiryMinutes: result.expiryMinutes,
+      },
+    });
+  } catch (error) {
+    console.error('Resend password reset OTP error:', error);
+
+    if (error.message === 'USER_NOT_FOUND') {
+      return res.status(200).json({
+        message: 'If an account with this email exists, a password reset code has been sent.',
+        data: {
+          email: req.body.email,
+        },
+      });
+    }
+
+    if (error.message === 'OTP_COOLDOWN') {
+      return res.status(400).json({
+        message: `Please wait ${error.remainingSeconds} seconds before requesting a new code`,
+        error: 'OTP_COOLDOWN',
+        retryAfterSeconds: error.remainingSeconds,
+      });
+    }
+
+    if (error.message === 'STORAGE_ERROR') {
+      return sendErrorResponse(res, AUTH_ERRORS.STORAGE_ERROR);
+    }
+
+    if (error.message === 'EMAIL_ERROR') {
+      return sendErrorResponse(res, AUTH_ERRORS.EMAIL_ERROR);
+    }
+
+    return sendErrorResponse(res, AUTH_ERRORS.SERVER_ERROR);
+  }
+}

--- a/backend/user-service/middleware/validation.js
+++ b/backend/user-service/middleware/validation.js
@@ -93,6 +93,53 @@ export const userSchemas = {
         'any.required': 'OTP is required',
       }),
   }),
+
+  initiatePasswordReset: Joi.object({
+    email: Joi.string().email().required().messages({
+      'string.email': 'Please provide a valid email address',
+      'any.required': 'Email is required',
+    }),
+  }),
+
+  verifyPasswordResetOTP: Joi.object({
+    email: Joi.string().email().required().messages({
+      'string.email': 'Please provide a valid email address',
+      'any.required': 'Email is required',
+    }),
+    otp: Joi.string()
+      .pattern(/^\d{6}$/)
+      .required()
+      .messages({
+        'string.pattern.base': 'OTP must be a 6-digit number',
+        'any.required': 'OTP is required',
+      }),
+  }),
+
+  resetPassword: Joi.object({
+    email: Joi.string().email().required().messages({
+      'string.email': 'Please provide a valid email address',
+      'any.required': 'Email is required',
+    }),
+    otp: Joi.string()
+      .pattern(/^\d{6}$/)
+      .required()
+      .messages({
+        'string.pattern.base': 'OTP must be a 6-digit number',
+        'any.required': 'OTP is required',
+      }),
+    newPassword: Joi.string()
+      .min(6)
+      .max(128)
+      .pattern(new RegExp('^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9])'))
+      .required()
+      .messages({
+        'string.min': 'Password must be at least 6 characters long',
+        'string.max': 'Password cannot exceed 128 characters',
+        'string.pattern.base':
+          'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character',
+        'any.required': 'New password is required',
+      }),
+  }),
 };
 
 /**

--- a/backend/user-service/routes/auth-routes.js
+++ b/backend/user-service/routes/auth-routes.js
@@ -8,6 +8,12 @@ import {
   handleVerifyToken,
 } from '../controller/auth-controller.js';
 import {
+  handleInitiatePasswordReset,
+  handleResendPasswordResetOTP,
+  handleResetPassword,
+  handleVerifyPasswordResetOTP,
+} from '../controller/password-reset-controller.js';
+import {
   handleCompleteRegistration,
   handleInitiateRegistration,
   handleResendRegistrationOTP,
@@ -40,7 +46,26 @@ router.post(
 );
 router.post('/register/resend-otp', normalizeEmail, handleResendRegistrationOTP);
 
-// Old registration endpoint (kept for backward compatibility)
+router.post(
+  '/password-reset/initiate',
+  normalizeEmail,
+  validate(userSchemas.initiatePasswordReset),
+  handleInitiatePasswordReset,
+);
+router.post(
+  '/password-reset/verify',
+  normalizeEmail,
+  validate(userSchemas.verifyPasswordResetOTP),
+  handleVerifyPasswordResetOTP,
+);
+router.post(
+  '/password-reset/reset',
+  normalizeEmail,
+  validate(userSchemas.resetPassword),
+  handleResetPassword,
+);
+router.post('/password-reset/resend-otp', normalizeEmail, handleResendPasswordResetOTP);
+
 router.post('/register', normalizeEmail, normalizeUsername, validateCreateUser, createUser);
 
 // Login endpoint

--- a/backend/user-service/services/password-reset-service.js
+++ b/backend/user-service/services/password-reset-service.js
@@ -1,0 +1,176 @@
+import argon2 from 'argon2';
+import { UserRepository } from '../model/user-repository.js';
+import { emailService } from './email-service.js';
+import { otpService } from './otp-service.js';
+import { otpRedisService } from './redis/redis-otp-service.js';
+
+const OTP_PURPOSE = 'password-reset';
+
+export async function initiatePasswordReset(email) {
+  const normalizedEmail = email.toLowerCase();
+
+  const user = await UserRepository.findByEmail(normalizedEmail);
+  if (!user) {
+    throw new Error('USER_NOT_FOUND');
+  }
+
+  const existingOTP = await otpRedisService.getOTP(normalizedEmail, OTP_PURPOSE);
+  if (existingOTP) {
+    const remainingTime = Math.max(0, Math.floor((existingOTP.expiresAt - Date.now()) / 1000));
+    if (remainingTime > 240) {
+      const error = new Error('OTP_COOLDOWN');
+      error.remainingSeconds = remainingTime;
+      throw error;
+    }
+  }
+
+  const otpData = otpService.generateOTPData(normalizedEmail, OTP_PURPOSE);
+  const otpStored = await otpRedisService.storeOTP(normalizedEmail, otpData, OTP_PURPOSE);
+  if (!otpStored) {
+    throw new Error('STORAGE_ERROR');
+  }
+
+  try {
+    await emailService.sendOTP(normalizedEmail, otpData.otp, 'Password Reset', {
+      username: user.username,
+      expiryMinutes: Math.floor(otpData.ttl / 60),
+    });
+  } catch (error) {
+    console.error('Failed to send password reset OTP email:', error);
+    throw new Error('EMAIL_ERROR');
+  }
+
+  return {
+    email: normalizedEmail,
+    expiryMinutes: Math.floor(otpData.ttl / 60),
+  };
+}
+
+export async function verifyPasswordResetOTP(email, otp) {
+  if (!otp) {
+    throw new Error('MISSING_OTP');
+  }
+
+  const normalizedEmail = email.toLowerCase();
+
+  const user = await UserRepository.findByEmail(normalizedEmail);
+  if (!user) {
+    throw new Error('USER_NOT_FOUND');
+  }
+
+  const storedOTPData = await otpRedisService.getOTP(normalizedEmail, OTP_PURPOSE);
+  const validationResult = otpService.validateOTP(storedOTPData, otp, normalizedEmail, OTP_PURPOSE);
+
+  if (!validationResult.isValid) {
+    if (storedOTPData && !validationResult.shouldDelete) {
+      await otpRedisService.incrementOTPAttempts(normalizedEmail, OTP_PURPOSE);
+    }
+    if (validationResult.shouldDelete) {
+      await otpRedisService.deleteOTP(normalizedEmail, OTP_PURPOSE);
+    }
+
+    const error = new Error('INVALID_OTP');
+    error.validationResult = validationResult;
+    throw error;
+  }
+
+  await otpRedisService.deleteOTP(normalizedEmail, OTP_PURPOSE);
+
+  return {
+    email: normalizedEmail,
+    verified: true,
+  };
+}
+
+export async function resetPassword(email, otp, newPassword) {
+  if (!otp) {
+    throw new Error('MISSING_OTP');
+  }
+
+  if (!newPassword) {
+    throw new Error('MISSING_PASSWORD');
+  }
+
+  const normalizedEmail = email.toLowerCase();
+
+  const user = await UserRepository.findByEmail(normalizedEmail);
+  if (!user) {
+    throw new Error('USER_NOT_FOUND');
+  }
+
+  const storedOTPData = await otpRedisService.getOTP(normalizedEmail, OTP_PURPOSE);
+  const validationResult = otpService.validateOTP(storedOTPData, otp, normalizedEmail, OTP_PURPOSE);
+
+  if (!validationResult.isValid) {
+    if (storedOTPData && !validationResult.shouldDelete) {
+      await otpRedisService.incrementOTPAttempts(normalizedEmail, OTP_PURPOSE);
+    }
+    if (validationResult.shouldDelete) {
+      await otpRedisService.deleteOTP(normalizedEmail, OTP_PURPOSE);
+    }
+
+    const error = new Error('INVALID_OTP');
+    error.validationResult = validationResult;
+    throw error;
+  }
+
+  const hashedPassword = await argon2.hash(newPassword, {
+    type: argon2.argon2id,
+    memoryCost: parseInt(process.env.ARGON2_MEMORY_COST),
+    timeCost: parseInt(process.env.ARGON2_TIME_COST),
+    parallelism: parseInt(process.env.ARGON2_PARALLELISM),
+    hashLength: parseInt(process.env.ARGON2_HASH_LENGTH),
+    saltLength: parseInt(process.env.ARGON2_SALT_LENGTH),
+  });
+
+  await UserRepository.updatePassword(user._id, hashedPassword);
+
+  await otpRedisService.deleteOTP(normalizedEmail, OTP_PURPOSE);
+
+  console.log(`Password reset successful for user ${normalizedEmail}`);
+
+  return {
+    success: true,
+    email: normalizedEmail,
+  };
+}
+
+export async function resendPasswordResetOTP(email) {
+  const normalizedEmail = email.toLowerCase();
+
+  const user = await UserRepository.findByEmail(normalizedEmail);
+  if (!user) {
+    throw new Error('USER_NOT_FOUND');
+  }
+
+  const existingOTP = await otpRedisService.getOTP(normalizedEmail, OTP_PURPOSE);
+  if (existingOTP) {
+    const remainingTime = Math.max(0, Math.floor((existingOTP.expiresAt - Date.now()) / 1000));
+    if (remainingTime > 240) {
+      const error = new Error('OTP_COOLDOWN');
+      error.remainingSeconds = remainingTime;
+      throw error;
+    }
+  }
+
+  const otpData = otpService.generateOTPData(normalizedEmail, OTP_PURPOSE);
+  const otpStored = await otpRedisService.storeOTP(normalizedEmail, otpData, OTP_PURPOSE);
+  if (!otpStored) {
+    throw new Error('STORAGE_ERROR');
+  }
+
+  try {
+    await emailService.sendOTP(normalizedEmail, otpData.otp, 'Password Reset', {
+      username: user.username,
+      expiryMinutes: Math.floor(otpData.ttl / 60),
+    });
+  } catch (error) {
+    console.error('Failed to resend password reset OTP email:', error);
+    throw new Error('EMAIL_ERROR');
+  }
+
+  return {
+    email: normalizedEmail,
+    expiryMinutes: Math.floor(otpData.ttl / 60),
+  };
+}


### PR DESCRIPTION
This pull request adds a complete OTP-based "forgot password" workflow to the user service, allowing users to securely reset their passwords via email verification. The implementation includes new API endpoints, controller logic, service methods, and request validation for initiating password resets, verifying OTPs, resetting passwords, and resending OTPs.

**Forgot Password Feature Implementation**

* Added four new API endpoints for password reset: initiate, verify OTP, reset password, and resend OTP, with documentation in `README.md` and endpoint summary. [[1]](diffhunk://#diff-9f28aa2b4571793be96d6071f626e6783ffb0f658dc1a94708fd9b81f2ce9b7cR553-R651) [[2]](diffhunk://#diff-9f28aa2b4571793be96d6071f626e6783ffb0f658dc1a94708fd9b81f2ce9b7cR663-R666)
* Implemented controller logic in `password-reset-controller.js` to handle password reset actions, including error handling for user not found, OTP cooldown, and invalid OTP scenarios.
* Created service methods in `password-reset-service.js` for generating, validating, and deleting OTPs, securely updating user passwords with Argon2, and integrating with Redis and email services.

**Validation and Routing**

* Added Joi validation schemas for password reset requests (`initiate`, `verify OTP`, `reset password`) to ensure correct input formats and password strength requirements.
* Integrated new controller handlers and validation into `auth-routes.js`, wiring up the endpoints with middleware for normalization and validation. [[1]](diffhunk://#diff-1de4eb0669dc46ba8f349cd7cb84656821c2644a5071e8b88988a4456df02882R10-R15) [[2]](diffhunk://#diff-1de4eb0669dc46ba8f349cd7cb84656821c2644a5071e8b88988a4456df02882L43-R68)

close: #91 